### PR TITLE
Add enemy attack logic and damage feedback

### DIFF
--- a/inc/Enemy.h
+++ b/inc/Enemy.h
@@ -13,13 +13,18 @@ protected:
     int damage;
     float speed;
     Vector2 gridPosition;
+    float attackCooldown;
+    float attackTimer;
+    float hurtTimer;
 
 public:
     Enemy(EnemyType t, int hp, int dmg, float spd, Vector2 pos);
-    
+
     virtual void Update(float deltaTime, Player* player);
     virtual void Draw() const override = 0;
-    
+
+    virtual void Attack(Player* player);
+
     void TakeDamage(int dmg);
     bool CheckCollision(const Player* player) const;
     

--- a/src/Entities/Enemies/Pizzabox.cpp
+++ b/src/Entities/Enemies/Pizzabox.cpp
@@ -6,6 +6,7 @@ PizzaBox::PizzaBox(Vector2 pos) : Enemy(EnemyType::PIZZA_BOX, 40, 8, 1.5f, pos) 
 void PizzaBox::Update(float deltaTime) {}
 void PizzaBox::Draw() const {
     Vector2 screenPos = {400 + transform.position.x, 300 + transform.position.y};
-    DrawRectangle(screenPos.x - 16, screenPos.y - 4, 32, 8, ORANGE);
+    Color c = hurtTimer > 0 ? RED : ORANGE;
+    DrawRectangle(screenPos.x - 16, screenPos.y - 4, 32, 8, c);
     DrawText("P", screenPos.x - 6, screenPos.y - 8, 16, BLACK);
 }

--- a/src/Entities/Enemies/Slime.cpp
+++ b/src/Entities/Enemies/Slime.cpp
@@ -6,6 +6,7 @@ Slime::Slime(Vector2 pos) : Enemy(EnemyType::SLIME, 30, 10, 2.0f, pos) {}
 void Slime::Update(float deltaTime) {}
 void Slime::Draw() const {
     Vector2 screenPos = {400 + transform.position.x, 300 + transform.position.y};
-    DrawCircle(screenPos.x, screenPos.y, 16, GREEN);
+    Color c = hurtTimer > 0 ? RED : GREEN;
+    DrawCircle(screenPos.x, screenPos.y, 16, c);
     DrawText("S", screenPos.x - 6, screenPos.y - 8, 16, BLACK);
 }

--- a/src/Entities/Enemies/SodaCan.cpp
+++ b/src/Entities/Enemies/SodaCan.cpp
@@ -6,6 +6,7 @@ SodaCan::SodaCan(Vector2 pos) : Enemy(EnemyType::SODA_CAN, 20, 15, 3.0f, pos) {}
 void SodaCan::Update(float deltaTime) {}
 void SodaCan::Draw() const {
     Vector2 screenPos = {400 + transform.position.x, 300 + transform.position.y};
-    DrawRectangle(screenPos.x - 8, screenPos.y - 12, 16, 24, RED);
+    Color c = hurtTimer > 0 ? MAROON : RED;
+    DrawRectangle(screenPos.x - 8, screenPos.y - 12, 16, 24, c);
     DrawText("C", screenPos.x - 6, screenPos.y - 8, 16, WHITE);
 }

--- a/src/Entities/Enemy.cpp
+++ b/src/Entities/Enemy.cpp
@@ -5,11 +5,17 @@
 #include <cmath>
 
 Enemy::Enemy(EnemyType t, int hp, int dmg, float spd, Vector2 pos) :
-    type(t), health(hp), maxHealth(hp), 
-    damage(dmg), speed(spd), gridPosition(pos) {}
+    type(t), health(hp), maxHealth(hp),
+    damage(dmg), speed(spd), gridPosition(pos),
+    attackCooldown(1.0f), attackTimer(0.0f), hurtTimer(0.0f) {}
 
 void Enemy::Update(float deltaTime, Player* player) {
     if (!isActive) return;
+
+    attackTimer += deltaTime;
+    if (hurtTimer > 0.0f) {
+        hurtTimer -= deltaTime;
+    }
     
     // Simple AI - move towards player
     Vector2 direction = {
@@ -21,20 +27,31 @@ void Enemy::Update(float deltaTime, Player* player) {
     if (length > 0) {
         direction.x /= length;
         direction.y /= length;
-        
+
         gridPosition.x += direction.x * speed * deltaTime;
         gridPosition.y += direction.y * speed * deltaTime;
     }
     
     transform.position = Utils::WorldToIso(gridPosition);
+
+    if (CheckCollision(player) && attackTimer >= attackCooldown) {
+        Attack(player);
+        attackTimer = 0.0f;
+    }
 }
 
 void Enemy::TakeDamage(int dmg) {
     health -= dmg;
+    hurtTimer = 0.2f;
     if (health <= 0) {
         health = 0;
         isActive = false;
     }
+}
+
+void Enemy::Attack(Player* player) {
+    if (player)
+        player->TakeDamage(damage);
 }
 
 bool Enemy::CheckCollision(const Player* player) const {

--- a/src/Game/GameManager.cpp
+++ b/src/Game/GameManager.cpp
@@ -90,11 +90,10 @@ void GameManager::UpdateArena(float deltaTime) {
     waveManager->Update(deltaTime, enemies);
     
     for (auto& enemy : enemies) {
+        int prevHealth = enemy->GetHealth();
         enemy->Update(deltaTime, player.get());
-        
-        if (enemy->IsAlive() && enemy->CheckCollision(player.get())) {
-            player->TakeDamage(enemy->GetDamage());
-            enemy->TakeDamage(100); // Instant kill for now
+
+        if (prevHealth > 0 && !enemy->IsAlive()) {
             AddScore(10);
         }
     }


### PR DESCRIPTION
## Summary
- let enemies attack instead of suiciding on player collision
- award score only when enemies die
- flash enemy sprites red when hurt

## Testing
- `cmake .. && make -j$(nproc)` *(fails: raylib missing)*

------
https://chatgpt.com/codex/tasks/task_e_6862ed6d70108325b6e7b8a6f1c108a7