### PR TITLE
Add mouse-based attacking and range indicator

### DIFF
--- a/inc/Entities/Player.h
+++ b/inc/Entities/Player.h
@@ -16,6 +16,12 @@ private:
     std::unique_ptr<Weapon> weapon;
     std::vector<std::unique_ptr<Ability>> abilities;
 
+    // Attack state
+    bool isAttacking;
+    float attackTimer;
+    float attackDuration;
+    Vector2 attackDir;
+
 public:
     Player();
     
@@ -23,8 +29,11 @@ public:
     void Draw() const override;
     
     void TakeDamage(int damage);
-    void Attack();
+    void Attack(Vector2 direction);
     void UseAbility(int index);
+
+    bool IsAttacking() const { return isAttacking; }
+    Vector2 GetAttackDir() const { return attackDir; }
     
     // Getters
     int GetHealth() const { return health; }

--- a/inc/Game/Utils.h
+++ b/inc/Game/Utils.h
@@ -11,6 +11,13 @@ namespace Utils {
         };
     }
 
+    inline Vector2 IsoToWorld(Vector2 isoPos) {
+        return {
+            (isoPos.x / 32.0f + isoPos.y / 16.0f) * 0.5f,
+            (isoPos.y / 16.0f - isoPos.x / 32.0f) * 0.5f
+        };
+    }
+
     // Clamp value between min and max
     template<typename T>
     inline T Clamp(T value, T min, T max) {

--- a/inc/Player.h
+++ b/inc/Player.h
@@ -17,6 +17,12 @@ private:
     std::unique_ptr<Weapon> weapon;
     std::vector<std::unique_ptr<Ability>> abilities;
 
+    // Attack state
+    bool isAttacking;
+    float attackTimer;
+    float attackDuration;
+    Vector2 attackDir;
+
 public:
     Player();
     
@@ -24,10 +30,12 @@ public:
     void Draw() const override;
     
     void TakeDamage(int damage);
-    void Attack();
+    void Attack(Vector2 direction);
     void UseAbility(int index);
 
     Vector2 GetLastMoveDir() const { return lastMoveDir; }
+    bool IsAttacking() const { return isAttacking; }
+    Vector2 GetAttackDir() const { return attackDir; }
     
     // Getters
     int GetHealth() const { return health; }

--- a/inc/Utils.h
+++ b/inc/Utils.h
@@ -11,6 +11,14 @@ namespace Utils {
         };
     }
 
+    // Convert isometric screen coordinates back to world grid coordinates
+    inline Vector2 IsoToWorld(Vector2 isoPos) {
+        return {
+            (isoPos.x / 32.0f + isoPos.y / 16.0f) * 0.5f,
+            (isoPos.y / 16.0f - isoPos.x / 32.0f) * 0.5f
+        };
+    }
+
     // Clamp value between min and max
     template<typename T>
     inline T Clamp(T value, T min, T max) {

--- a/src/Game/GameManager.cpp
+++ b/src/Game/GameManager.cpp
@@ -5,6 +5,7 @@
 #include "Utils.h"
 #include "raylib.h"
 #include <ranges>
+#include <cmath>
 
 GameManager::GameManager() : 
     currentState(GameState::MAIN_MENU),
@@ -68,11 +69,25 @@ void GameManager::UpdateArena(float deltaTime) {
     }
     
     gameTimer += deltaTime;
-    if (IsKeyPressed(KEY_SPACE)) {
-        player->Attack();
+    if (IsMouseButtonPressed(MOUSE_LEFT_BUTTON)) {
+        Vector2 mouse = GetMousePosition();
+        Vector2 iso = { mouse.x - 400, mouse.y - 300 };
+        Vector2 world = Utils::IsoToWorld(iso);
+
+        Vector2 dir = {
+            world.x - player->GetGridPosition().x,
+            world.y - player->GetGridPosition().y
+        };
+
+        float len = sqrtf(dir.x * dir.x + dir.y * dir.y);
+        if (len > 0) {
+            dir.x /= len;
+            dir.y /= len;
+        }
+
+        player->Attack(dir);
 
         Vector2 atkPos = player->GetGridPosition();
-        Vector2 dir = player->GetLastMoveDir();
         atkPos.x += dir.x;
         atkPos.y += dir.y;
 


### PR DESCRIPTION
## Summary
- compute world position from mouse with new `IsoToWorld` util
- track attack state inside `Player` and show circle when attacking
- allow attacking toward cursor with left mouse button

## Testing
- `cmake --build .` *(fails: raylib not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862efb91cc083258f96b631c484c041