### PR TITLE
Fix kill scoring

### DIFF
--- a/src/Game/GameManager.cpp
+++ b/src/Game/GameManager.cpp
@@ -97,7 +97,11 @@ void GameManager::UpdateArena(float deltaTime) {
             float dx = epos.x - atkPos.x;
             float dy = epos.y - atkPos.y;
             if (dx * dx + dy * dy <= 1.0f) {
+                bool wasAlive = enemy->IsAlive();
                 enemy->TakeDamage(player->GetWeapon()->GetDamage());
+                if (wasAlive && !enemy->IsAlive()) {
+                    AddScore(10);
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary
- fix enemy attack handling so killing an enemy grants score and scraps immediately

## Testing
- `cmake ..`
- `make -j$(nproc)` *(fails: raylib.h missing)*

------
https://chatgpt.com/codex/tasks/task_e_6862f1c097448325b0664b3a9b7c111b