### PR TITLE
Implement wave scaling, collision, and persistent scraps

### DIFF
--- a/inc/Enemy.h
+++ b/inc/Enemy.h
@@ -2,6 +2,7 @@
 #include "Entity.h"
 #include "GameState.h"
 #include "EnemyType.h"
+#include "Utils.h"
 
 class Player;
 
@@ -27,6 +28,13 @@ public:
 
     void TakeDamage(int dmg);
     bool CheckCollision(const Player* player) const;
+
+    void SetGridPosition(Vector2 pos) { gridPosition = pos; transform.position = Utils::WorldToIso(gridPosition); }
+    void ScaleStats(float hpMult, float dmgMult) {
+        health = static_cast<int>(health * hpMult);
+        maxHealth = static_cast<int>(maxHealth * hpMult);
+        damage = static_cast<int>(damage * dmgMult);
+    }
     
     // Getters
     int GetDamage() const { return damage; }

--- a/inc/Entities/Player.h
+++ b/inc/Entities/Player.h
@@ -47,4 +47,5 @@ public:
     
     // Setters
     void AddScraps(int amount) { scraps += amount; }
+    void SetScraps(int amount) { scraps = amount; }
 };

--- a/inc/Game/GameManager.h
+++ b/inc/Game/GameManager.h
@@ -58,4 +58,5 @@ private:
     void InitializeMenus();
     void UpdateArena(float deltaTime);
     void CleanupEnemies();
+    void ResolveEnemyCollisions();
 };

--- a/inc/GameManager.h
+++ b/inc/GameManager.h
@@ -58,4 +58,5 @@ private:
     void InitializeMenus();
     void UpdateArena(float deltaTime);
     void CleanupEnemies();
+    void ResolveEnemyCollisions();
 };

--- a/inc/Player.h
+++ b/inc/Player.h
@@ -49,4 +49,5 @@ public:
     
     // Setters
     void AddScraps(int amount) { scraps += amount; }
+    void SetScraps(int amount) { scraps = amount; }
 };

--- a/inc/SaveSystem.h
+++ b/inc/SaveSystem.h
@@ -10,4 +10,6 @@ public:
     static int LoadHighScore();
     static void SaveSettings(float masterVolume, float sfxVolume, float musicVolume);
     static void LoadSettings(float& masterVolume, float& sfxVolume, float& musicVolume);
+    static void SaveScraps(int scraps);
+    static int LoadScraps();
 };

--- a/inc/Systems/SaveSystem.h
+++ b/inc/Systems/SaveSystem.h
@@ -8,4 +8,6 @@ public:
     static int LoadHighScore();
     static void SaveSettings(float masterVolume, float sfxVolume, float musicVolume);
     static void LoadSettings(float& masterVolume, float& sfxVolume, float& musicVolume);
+    static void SaveScraps(int scraps);
+    static int LoadScraps();
 };

--- a/inc/Systems/WaveManager.h
+++ b/inc/Systems/WaveManager.h
@@ -10,6 +10,9 @@ private:
     float spawnTimer;
     int enemiesSpawned;
     int enemiesToSpawn;
+    float spawnInterval;
+    float healthMultiplier;
+    float damageMultiplier;
     
 public:
     WaveManager();

--- a/inc/WaveManager.h
+++ b/inc/WaveManager.h
@@ -10,6 +10,9 @@ private:
     float spawnTimer;
     int enemiesSpawned;
     int enemiesToSpawn;
+    float spawnInterval;
+    float healthMultiplier;
+    float damageMultiplier;
     
 public:
     WaveManager();

--- a/src/Game/GameManager.cpp
+++ b/src/Game/GameManager.cpp
@@ -21,6 +21,7 @@ GameManager::GameManager() :
     hud = std::make_unique<HUD>();
     
     highScore = SaveSystem::LoadHighScore();
+    player->SetScraps(SaveSystem::LoadScraps());
     InitializeMenus();
 }
 
@@ -116,6 +117,8 @@ void GameManager::UpdateArena(float deltaTime) {
             AddScore(10);
         }
     }
+
+    ResolveEnemyCollisions();
     
     if (player->GetHealth() <= 0) {
         if (score > highScore) {
@@ -134,6 +137,36 @@ void GameManager::CleanupEnemies() {
             return !enemy->IsAlive();
         });
     enemies.erase(subrange.begin(), subrange.end());
+}
+
+void GameManager::ResolveEnemyCollisions() {
+    const float minDist = 0.8f;
+    for (size_t i = 0; i < enemies.size(); ++i) {
+        for (size_t j = i + 1; j < enemies.size(); ++j) {
+            if (!enemies[i]->IsAlive() || !enemies[j]->IsAlive()) continue;
+            Vector2 posA = enemies[i]->GetGridPosition();
+            Vector2 posB = enemies[j]->GetGridPosition();
+            float dx = posB.x - posA.x;
+            float dy = posB.y - posA.y;
+            float distSq = dx * dx + dy * dy;
+            if (distSq < minDist * minDist && distSq > 0.0001f) {
+                float dist = sqrtf(distSq);
+                float overlap = (minDist - dist) / 2.0f;
+                dx /= dist;
+                dy /= dist;
+                posA.x -= dx * overlap;
+                posA.y -= dy * overlap;
+                posB.x += dx * overlap;
+                posB.y += dy * overlap;
+                posA.x = Utils::Clamp(posA.x, 0.0f, 20.0f);
+                posA.y = Utils::Clamp(posA.y, 0.0f, 20.0f);
+                posB.x = Utils::Clamp(posB.x, 0.0f, 20.0f);
+                posB.y = Utils::Clamp(posB.y, 0.0f, 20.0f);
+                enemies[i]->SetGridPosition(posA);
+                enemies[j]->SetGridPosition(posB);
+            }
+        }
+    }
 }
 
 void GameManager::Draw() {
@@ -192,6 +225,7 @@ void GameManager::SetGameState(GameState state) {
 
 void GameManager::ResetGame() {
     player = std::make_unique<Player>();
+    player->SetScraps(SaveSystem::LoadScraps());
     enemies.clear();
     waveManager = std::make_unique<WaveManager>();
     score = 0;
@@ -201,6 +235,7 @@ void GameManager::ResetGame() {
 void GameManager::AddScore(int amount) {
     score += amount;
     player->AddScraps(amount / 10); // Convert some score to scraps
+    SaveSystem::SaveScraps(player->GetScraps());
 }
 
 bool GameManager::ShouldClose() const {

--- a/src/Systems/SaveSystem.cpp
+++ b/src/Systems/SaveSystem.cpp
@@ -47,3 +47,24 @@ void SaveSystem::LoadSettings(float& masterVolume, float& sfxVolume, float& musi
         musicVolume = 0.4f;
     }
 }
+
+void SaveSystem::SaveScraps(int scraps) {
+    std::thread([scraps]() {
+        fs::path dir = fs::current_path() / "saves";
+        fs::create_directories(dir);
+        std::ofstream file(dir / "scraps.txt");
+        if (file.is_open()) {
+            file << scraps;
+        }
+    }).detach();
+}
+
+int SaveSystem::LoadScraps() {
+    fs::path path = fs::current_path() / "saves" / "scraps.txt";
+    std::ifstream file(path);
+    int scraps = 0;
+    if (file.is_open()) {
+        file >> scraps;
+    }
+    return scraps;
+}

--- a/src/Systems/WaveManager.cpp
+++ b/src/Systems/WaveManager.cpp
@@ -5,13 +5,14 @@
 #include "raylib.h"
 #include <algorithm>
 
-WaveManager::WaveManager() 
-    : currentWave(1), waveTimer(0), spawnTimer(0), enemiesSpawned(0), enemiesToSpawn(5) {}
+WaveManager::WaveManager()
+    : currentWave(1), waveTimer(0), spawnTimer(0), enemiesSpawned(0), enemiesToSpawn(5),
+      spawnInterval(2.0f), healthMultiplier(1.0f), damageMultiplier(1.0f) {}
 
 void WaveManager::Update(float deltaTime, std::vector<std::unique_ptr<Enemy>>& enemies) {
     spawnTimer += deltaTime;
     
-    if (enemiesSpawned < enemiesToSpawn && spawnTimer >= 2.0f) {
+    if (enemiesSpawned < enemiesToSpawn && spawnTimer >= spawnInterval) {
         SpawnEnemy(enemies);
         spawnTimer = 0;
     }
@@ -41,12 +42,15 @@ void WaveManager::SpawnEnemy(std::vector<std::unique_ptr<Enemy>>& enemies) {
     switch (enemyType) {
         case 0:
             enemies.push_back(std::make_unique<Slime>(spawnPos));
+            enemies.back()->ScaleStats(healthMultiplier, damageMultiplier);
             break;
         case 1:
             enemies.push_back(std::make_unique<SodaCan>(spawnPos));
+            enemies.back()->ScaleStats(healthMultiplier, damageMultiplier);
             break;
         case 2:
             enemies.push_back(std::make_unique<PizzaBox>(spawnPos));
+            enemies.back()->ScaleStats(healthMultiplier, damageMultiplier);
             break;
     }
     
@@ -57,6 +61,9 @@ void WaveManager::NextWave() {
     currentWave++;
     enemiesSpawned = 0;
     enemiesToSpawn += 2;
+    healthMultiplier *= 1.2f;
+    damageMultiplier *= 1.1f;
+    spawnInterval = std::max(0.5f, spawnInterval * 0.95f);
 }
 
 int WaveManager::GetCurrentWave() const {


### PR DESCRIPTION
## Summary
- increase enemy health, damage and spawn speed each wave
- resolve overlapping enemies
- keep collected scraps between runs
- declare collision resolver in the main GameManager header

## Testing
- `cmake -S . -B build_clean`
- `cmake --build build_clean` *(fails: `raylib.h` not found)*

------
https://chatgpt.com/codex/tasks/task_e_6862f41d2eb88325bdf1778b8fa08310