### PR TITLE
Enable shop from main menu and persist scraps

### DIFF
--- a/inc/SaveSystem.h
+++ b/inc/SaveSystem.h
@@ -6,8 +6,8 @@
 
 class SaveSystem {
 public:
-    static void SaveHighScore(int score);
-    static int LoadHighScore();
+    static void SaveHighScore(int score, int scraps);
+    static int LoadHighScore(int& scraps);
     static void SaveSettings(float masterVolume, float sfxVolume, float musicVolume);
     static void LoadSettings(float& masterVolume, float& sfxVolume, float& musicVolume);
     static void SaveScraps(int scraps);

--- a/inc/Systems/SaveSystem.h
+++ b/inc/Systems/SaveSystem.h
@@ -4,8 +4,8 @@
 
 class SaveSystem {
 public:
-    static void SaveHighScore(int score);
-    static int LoadHighScore();
+    static void SaveHighScore(int score, int scraps);
+    static int LoadHighScore(int& scraps);
     static void SaveSettings(float masterVolume, float sfxVolume, float musicVolume);
     static void LoadSettings(float& masterVolume, float& sfxVolume, float& musicVolume);
     static void SaveScraps(int scraps);

--- a/src/Game/GameManager.cpp
+++ b/src/Game/GameManager.cpp
@@ -21,8 +21,9 @@ GameManager::GameManager() :
     audioManager = std::make_unique<AudioManager>();
     hud = std::make_unique<HUD>();
     
-    highScore = SaveSystem::LoadHighScore();
-    player->SetScraps(SaveSystem::LoadScraps());
+    int loadedScraps = 0;
+    highScore = SaveSystem::LoadHighScore(loadedScraps);
+    player->SetScraps(loadedScraps);
     player->SetWeapon(CreateWeaponFromName(SaveSystem::LoadWeapon()));
     InitializeMenus();
 }
@@ -132,9 +133,8 @@ void GameManager::UpdateArena(float deltaTime) {
     if (player->GetHealth() <= 0) {
         if (score > highScore) {
             highScore = score;
-            SaveSystem::SaveHighScore(highScore);
         }
-        SaveSystem::SaveScraps(player->GetScraps());
+        SaveSystem::SaveHighScore(highScore, player->GetScraps());
         SetGameState(GameState::GAME_OVER);
     }
     
@@ -269,7 +269,11 @@ void GameManager::SetGameState(GameState state) {
 
 void GameManager::ResetGame() {
     player = std::make_unique<Player>();
-    player->SetScraps(SaveSystem::LoadScraps());
+    {
+        int loadedScraps = 0;
+        SaveSystem::LoadHighScore(loadedScraps);
+        player->SetScraps(loadedScraps);
+    }
     player->SetWeapon(CreateWeaponFromName(SaveSystem::LoadWeapon()));
     enemies.clear();
     waveManager = std::make_unique<WaveManager>();

--- a/src/Systems/SaveSystem.cpp
+++ b/src/Systems/SaveSystem.cpp
@@ -4,23 +4,25 @@
 
 namespace fs = std::filesystem;
 
-void SaveSystem::SaveHighScore(int score) {
-    std::thread([score]() {
+void SaveSystem::SaveHighScore(int score, int scraps) {
+    std::thread([score, scraps]() {
         fs::path dir = fs::current_path() / "saves";
         fs::create_directories(dir);
         std::ofstream file(dir / "highscore.txt");
         if (file.is_open()) {
-            file << score;
+            file << score << ' ' << scraps;
         }
     }).detach();
 }
 
-int SaveSystem::LoadHighScore() {
+int SaveSystem::LoadHighScore(int& scraps) {
     fs::path path = fs::current_path() / "saves" / "highscore.txt";
     std::ifstream file(path);
     int score = 0;
     if (file.is_open()) {
-        file >> score;
+        file >> score >> scraps;
+    } else {
+        scraps = 0;
     }
     return score;
 }
@@ -49,23 +51,14 @@ void SaveSystem::LoadSettings(float& masterVolume, float& sfxVolume, float& musi
 }
 
 void SaveSystem::SaveScraps(int scraps) {
-    std::thread([scraps]() {
-        fs::path dir = fs::current_path() / "saves";
-        fs::create_directories(dir);
-        std::ofstream file(dir / "scraps.txt");
-        if (file.is_open()) {
-            file << scraps;
-        }
-    }).detach();
+    int currentScraps = 0;
+    int currentScore = LoadHighScore(currentScraps);
+    SaveHighScore(currentScore, scraps);
 }
 
 int SaveSystem::LoadScraps() {
-    fs::path path = fs::current_path() / "saves" / "scraps.txt";
-    std::ifstream file(path);
     int scraps = 0;
-    if (file.is_open()) {
-        file >> scraps;
-    }
+    LoadHighScore(scraps);
     return scraps;
 }
 

--- a/src/UI/MainMenu.cpp
+++ b/src/UI/MainMenu.cpp
@@ -4,24 +4,28 @@
 MainMenu::MainMenu(GameManager* gm) : Menu(gm), selectedMenuItem(0) {}
 
 void MainMenu::Update() {
+    const int menuCount = 5;
     if (IsKeyPressed(KEY_UP)) {
-        selectedMenuItem = (selectedMenuItem - 1 + 4) % 4;
+        selectedMenuItem = (selectedMenuItem - 1 + menuCount) % menuCount;
     }
     if (IsKeyPressed(KEY_DOWN)) {
-        selectedMenuItem = (selectedMenuItem + 1) % 4;
+        selectedMenuItem = (selectedMenuItem + 1) % menuCount;
     }
     if (IsKeyPressed(KEY_ENTER)) {
         switch (selectedMenuItem) {
             case 0: // Play
                 gameManager->SetGameState(GameState::ARENA);
                 break;
-            case 1: // Settings
+            case 1: // Shop
+                gameManager->SetGameState(GameState::SHOP);
+                break;
+            case 2: // Settings
                 gameManager->SetGameState(GameState::SETTINGS);
                 break;
-            case 2: // Credits
+            case 3: // Credits
                 gameManager->SetGameState(GameState::CREDITS);
                 break;
-            case 3: // Exit
+            case 4: // Exit
                 gameManager->SetShouldClose(true);
                 break;
         }
@@ -31,11 +35,13 @@ void MainMenu::Update() {
 void MainMenu::Draw() {
     DrawText("RACCOON RAMPAGE", 250, 100, 40, GREEN);
     
-    const char* menuItems[] = {"PLAY", "SETTINGS", "CREDITS", "EXIT"};
-    for (int i = 0; i < 4; i++) {
+    const char* menuItems[] = {"PLAY", "SHOP", "SETTINGS", "CREDITS", "EXIT"};
+    const int menuCount = 5;
+    for (int i = 0; i < menuCount; i++) {
         Color textColor = (i == selectedMenuItem) ? YELLOW : WHITE;
         DrawText(menuItems[i], 350, 200 + i * 50, 30, textColor);
     }
-    
+
     DrawText(TextFormat("HIGH SCORE: %d", gameManager->GetHighScore()), 300, 450, 20, WHITE);
+    DrawText(TextFormat("SCRAPS: %d", gameManager->GetPlayer()->GetScraps()), 300, 480, 20, YELLOW);
 }


### PR DESCRIPTION
## Summary
- make the shop available directly from the main menu
- show the player's scrap total on the main menu
- store scrap amount together with the highscore

## Testing
- `cmake --build build` *(fails: generator mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_686300c7ff308325953ccc19449d5059